### PR TITLE
Do not cancel touches in view

### DIFF
--- a/Sources/View+OnTouch.swift
+++ b/Sources/View+OnTouch.swift
@@ -78,6 +78,7 @@ struct TouchLocatingView: UIViewRepresentable {
         var touchTypes: OnTouchType = .all {
             didSet {
                 tapGesture.isEnabled = touchTypes.contains(.tapGesture)
+                tapGesture.cancelsTouchesInView = false
                 longPressGesture.isEnabled = touchTypes.contains(.longGestureStarted) || touchTypes.contains(.longGestureMoved) || touchTypes.contains(.longGestureEnded)
             }
         }


### PR DESCRIPTION
The tap gesture could previously prevent touches from reaching other views, such as a collection view.

Sets the `tapGesture` recognizer to not cancel touches in view, so that tap gestures are passed down the responder chain.